### PR TITLE
Ajoute l'option days_mode dans calculate_deadline

### DIFF
--- a/Koha/Plugin/Fr/UnivRennes2/WRM/lib/Koha/WarehouseRequest.pm
+++ b/Koha/Plugin/Fr/UnivRennes2/WRM/lib/Koha/WarehouseRequest.pm
@@ -128,7 +128,8 @@ sub archive {
 
 sub calculate_deadline {
     my ( $self, $days_to_keep ) = @_;
-    my $calendar = Koha::Calendar->new(branchcode => $self->branchcode);
+    my $calendar = Koha::Calendar->new(branchcode => $self->branchcode,
+                                       days_mode => C4::Context->preference('useDaysMode') );
     my $deadline = DateTime->now( time_zone => C4::Context->tz() );
     while ( $days_to_keep > 0 ) {
         $deadline = $calendar->next_open_days( $deadline, 1 );


### PR DESCRIPTION
Cela répare une erreur 500 via l'API. Avec Koha 20.11 on ne pouvait
plus rendre un document des magasins en traitement disponible :

    Missing mandatory option for Koha:Calendar->next_open_days: days_mode

Le Bug 24159 a rendu days_mode obligatoire pour plusieurs méthodes de
Koha::Calendar à partir de la 20.11 (voir
<https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=24159>).